### PR TITLE
Linear terms

### DIFF
--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -121,7 +121,7 @@ pub fn build_rulebook(book: &language::rulebook::RuleBook) -> (String, String) {
 pub fn build_function(
   book  : &language::rulebook::RuleBook,
   fname : &str,
-  rules : &[language::syntax::Rule],
+  rules : &[language::syntax::LinearRule],
 ) -> (String, String) {
   if let runtime::Function::Interpreted {
     smap: fn_smap,

--- a/src/language/readback.rs
+++ b/src/language/readback.rs
@@ -140,11 +140,12 @@ pub fn as_term(heap: &Heap, prog: &Program, host: u64) -> Box<language::syntax::
           stacks.push(col, old);
           got
         } else {
-          let val0 = runtime::load_arg(&ctx.heap, term, 0);
-          let val1 = runtime::load_arg(&ctx.heap, term, 1);
-          let val0 = readback(heap, prog, ctx, stacks, val0, depth + 1);
-          let val1 = readback(heap, prog, ctx, stacks, val1, depth + 1);
-          return Box::new(language::syntax::Term::Sup { val0, val1 });
+          //let val0 = runtime::load_arg(&ctx.heap, term, 0);
+          //let val1 = runtime::load_arg(&ctx.heap, term, 1);
+          //let val0 = readback(heap, prog, ctx, stacks, val0, depth + 1);
+          //let val1 = readback(heap, prog, ctx, stacks, val1, depth + 1);
+          //return Box::new(language::syntax::Term::Sup { val0, val1 });
+          unreachable!("unresolved SUP");
         }
       }
       runtime::DP0 => {

--- a/src/language/rulebook.rs
+++ b/src/language/rulebook.rs
@@ -295,12 +295,6 @@ pub fn sanitize_rule(rule: &language::syntax::Rule) -> Result<language::syntax::
           }
         }
       }
-      language::syntax::Term::Sup { val0, val1 } => {
-        let val0 = sanitize_term(val0, lhs, tbl, ctx)?;
-        let val1 = sanitize_term(val1, lhs, tbl, ctx)?;
-        let term = language::syntax::LinearTerm::Sup { val0, val1 };
-        Box::new(term)
-      }
       language::syntax::Term::Let { name, expr, body } => {
         if runtime::get_global_name_misc(name).is_some() {
           panic!("Global variable '{}' not allowed on let. Use dup instead.", name);
@@ -622,10 +616,6 @@ pub fn subst(term: &mut language::syntax::Term, sub_name: &str, value: &language
       if sub_name == name {
         *term = value.clone();
       }
-    }
-    language::syntax::Term::Sup { val0, val1 } => {
-      subst(&mut *val0, sub_name, value);
-      subst(&mut *val1, sub_name, value);
     }
     language::syntax::Term::Let { name, expr, body } => {
       subst(&mut *expr, sub_name, value);

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -53,6 +53,12 @@ pub struct Rule {
   pub rhs: Box<Term>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LinearRule {
+  pub lhs: Box<LinearTerm>,
+  pub rhs: Box<LinearTerm>,
+}
+
 // SMap
 // ----
 

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -11,7 +11,6 @@ use crate::runtime::data::f60;
 #[derive(Clone, Debug)]
 pub enum Term {
   Var { name: String }, // TODO: add `global: bool`
-  Dup { nam0: String, nam1: String, expr: Box<Term>, body: Box<Term> },
   Sup { val0: Box<Term>, val1: Box<Term> },
   Let { name: String, expr: Box<Term>, body: Box<Term> },
   Lam { name: String, body: Box<Term> },
@@ -153,7 +152,6 @@ impl std::fmt::Display for Term {
     }
     match self {
       Self::Var { name } => write!(f, "{}", name),
-      Self::Dup { nam0, nam1, expr, body } => write!(f, "dup {} {} = {}; {}", nam0, nam1, expr, body),
       Self::Sup { val0, val1 } => write!(f, "{{{} {}}}", val0, val1),
       Self::Let { name, expr, body } => write!(f, "let {} = {}; {}", name, expr, body),
       Self::Lam { name, body } => write!(f, "λ{} {}", name, body),
@@ -247,23 +245,6 @@ pub fn parse_let(state: HOPA::State) -> HOPA::Answer<Option<Box<Term>>> {
       let (state, _)    = HOPA::there_take_exact(";", state)?;
       let (state, body) = parse_term(state)?;
       Ok((state, Box::new(Term::Let { name, expr, body })))
-    }),
-    state,
-  );
-}
-
-pub fn parse_dup(state: HOPA::State) -> HOPA::Answer<Option<Box<Term>>> {
-  return HOPA::guard(
-    HOPA::do_there_take_exact("dup "),
-    Box::new(|state| {
-      let (state, _)    = HOPA::force_there_take_exact("dup ", state)?;
-      let (state, nam0) = HOPA::there_nonempty_name(state)?;
-      let (state, nam1) = HOPA::there_nonempty_name(state)?;
-      let (state, _)    = HOPA::force_there_take_exact("=", state)?;
-      let (state, expr) = parse_term(state)?;
-      let (state, _)    = HOPA::there_take_exact(";", state)?;
-      let (state, body) = parse_term(state)?;
-      Ok((state, Box::new(Term::Dup { nam0, nam1, expr, body })))
     }),
     state,
   );
@@ -604,7 +585,6 @@ pub fn parse_bng(state: HOPA::State) -> HOPA::Answer<Option<Box<Term>>> {
 pub fn parse_term(state: HOPA::State) -> HOPA::Answer<Box<Term>> {
   HOPA::attempt("Term", &[
     Box::new(parse_let),
-    Box::new(parse_dup),
     Box::new(parse_lam),
     Box::new(parse_ctr),
     Box::new(parse_op2),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ pub use runtime::{Ptr,
 pub use language::syntax::{
   Term,
   Term::Var, // TODO: add `global: bool`
-  Term::Dup,
   Term::Let,
   Term::Lam,
   Term::App,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -33,7 +33,7 @@ pub fn default_heap_size() -> usize {
 pub fn default_heap_tids() -> usize {
   return std::thread::available_parallelism().unwrap().get();
 }
-
+/*
 pub struct Runtime {
   pub heap: Heap,
   pub prog: Program,
@@ -391,3 +391,4 @@ impl Runtime {
     language::readback::as_linear_term(&self.heap, &self.prog, host)
   }
 }
+*/

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -387,7 +387,7 @@ impl Runtime {
   }
 
   /// Given a location, recovers the Term stored on it
-  pub fn linear_readback(&self, host: u64) -> Box<language::syntax::Term> {
+  pub fn linear_readback(&self, host: u64) -> Box<language::syntax::LinearTerm> {
     language::readback::as_linear_term(&self.heap, &self.prog, host)
   }
 }


### PR DESCRIPTION
probably the most presumptuous PR. this separates terms produce from code which can have the same variable appear more than once, and have no concept of `dup` and `sup`, from linear terms where every variable appears exactly once (those that don't appear are erased).

this makes the distinction strongly typed, and makes for less confusing API. users only need to produce and consume non-linear terms.